### PR TITLE
Keep using scrapper for proxy without auth connector

### DIFF
--- a/scrapper/main.go
+++ b/scrapper/main.go
@@ -1,4 +1,4 @@
-package scapper
+package scrapper
 
 import (
 	"bufio"


### PR DESCRIPTION
for some old teleports, retrieving the node list through tsh list doesn't work properly, hence we need to get through from the scrapper