### PR TITLE
Increase scraper timeout

### DIFF
--- a/scrapper/main.go
+++ b/scrapper/main.go
@@ -23,7 +23,7 @@ type Scrapper struct {
 func NewScrapper(p config.Proxy) *Scrapper {
 	return &Scrapper{
 		proxy:  p,
-		client: http.Client{Timeout: 30 * time.Second},
+		client: http.Client{Timeout: 60 * time.Second},
 	}
 }
 


### PR DESCRIPTION
Sometime for the large data it needs more than 30 second, so for now lets hardcoded to 60 seconds.
To ideal ways it should be configurable by user config file