### PR TITLE
fix(formatting): fix string to status parser

### DIFF
--- a/tsh/runner.go
+++ b/tsh/runner.go
@@ -172,6 +172,15 @@ func (t *TSH) parseStringToStatus(str string) *config.ProxyStatus {
 	lines := strings.Split(str, "\n")
 	res := &config.ProxyStatus{}
 	for _, line := range lines {
+		if line == "" {
+			/*
+				In order to support newer TSH version that has
+				Different formatting and the updated version is on the top
+				we need to break the loop if the line is empty
+			*/
+			break
+		}
+
 		kv := strings.Split(line, ":")
 		if len(kv) <= 1 {
 			continue


### PR DESCRIPTION
```
> Profile URL:        https://teleport-staging.redacted.net:3080
  Logged in as:       redacted@redacted.com
  Cluster:            main
  Roles:              engineer-digital-role
  Logins:             redacted@redacted.com, root
  Kubernetes:         disabled
  Valid until:        2024-01-26 22:26:47 +0700 WIB [valid for 7h21m0s]
  Extensions:         permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty

  Profile URL:        https://teleport.redacted.net:3080
  Logged in as:       redacted@redacted.com
  Cluster:            main
  Roles:              engineer-digital-role
  Logins:             redacted@redacted.com, non-admin
  Kubernetes:         disabled
  Valid until:        2024-01-26 22:25:02 +0700 WIB [valid for 7h19m0s]
  Extensions:         permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty
```

It is advisable to modify the string parser to accommodate the new version of tsh and retrieve the accurate logins for multiple environments. The currently logged-in environment will be positioned at the top.