### PR TITLE
Use $VISUAL and $EDITOR env vars for editor selection

### DIFF
--- a/editor/edit.go
+++ b/editor/edit.go
@@ -8,9 +8,8 @@ import (
 
 const DefaultEditor = "nano"
 
-// Edit edit the text using editor
+// Edit the text using editor
 func Edit(text string, tmpPattern string) (string, error) {
-
 	if tmpPattern == "" {
 		tmpPattern = "tpot_*.txt"
 	}
@@ -25,7 +24,15 @@ func Edit(text string, tmpPattern string) (string, error) {
 		return "", err
 	}
 
-	cmd := exec.Command(DefaultEditor, f.Name())
+	editor := os.Getenv("VISUAL")
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+		if editor == "" {
+			editor = DefaultEditor
+		}
+	}
+
+	cmd := exec.Command(editor, f.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Description

This pull request modifies the `Edit` function in the `editor` package to use the standard *nix convention of `VISUAL` and `EDITOR` environment variables for selecting the text editor. 

## Motivation and Context

Currently, the `Edit` function always uses the `DefaultEditor`, which is hardcoded as "nano". This limits the flexibility for users who prefer to use a different text editor.

## Changes

- Check if the `VISUAL` environment variable is set using `os.Getenv("VISUAL")`. If it is set, use its value as the editor.
- If `VISUAL` is not set, check if the `EDITOR` environment variable is set using `os.Getenv("EDITOR")`. If it is set, use its value as the editor.
- If neither `VISUAL` nor `EDITOR` is set, fall back to using the `DefaultEditor`, which is set to "nano".

## Verified

- Tested the modified code by setting the `VISUAL` environment variable to a different editor (e.g., "vim") and verified that the specified editor was used when calling the `Edit` function.
- Tested the case when neither `VISUAL` nor `EDITOR` is set and confirmed that it falls back to using "nano" as the default editor.

## Checklist

- [x] Tested the changes locally
- [x] Updated the code to follow the standard *nix convention
- [x] Provided clear commit message and pull request description

Please review and provide any feedback or suggestions for improvement.